### PR TITLE
Changed path for API calls in index.html of server to use relative path

### DIFF
--- a/larynx/templates/index.html
+++ b/larynx/templates/index.html
@@ -127,7 +127,7 @@
              var startTime = performance.now()
 
              res = await fetch(
-                 '/api/tts?text=' + encodeURIComponent(text) +
+                 'api/tts?text=' + encodeURIComponent(text) +
                  '&voice=' + encodeURIComponent(voice) +
                  '&vocoder=' + encodeURIComponent(vocoder) +
                  '&denoiserStrength=' + encodeURIComponent(denoiserStrength) +
@@ -157,7 +157,7 @@
                  voiceList.options[i].remove()
              }
 
-             fetch('/api/voices')
+             fetch('api/voices')
                  .then(function(res) {
                      if (!res.ok) throw Error(res.statusText)
                      return res.json()
@@ -177,7 +177,7 @@
          function loadPhonemes() {
              var language = 'en-us'
 
-             fetch('/api/phonemes?language=' + encodeURIComponent(language))
+             fetch('api/phonemes?language=' + encodeURIComponent(language))
                  .then(function(res) {
                      if (!res.ok) throw Error(res.statusText)
                      return res.json()


### PR DESCRIPTION
The index.html (templates folder) of the server always calls web-root via `/api/...` this path will break (as it did for me) when you use a proxy to point at the Larynx server, e.g. `http://raspberrypi.local/sepia/larynx/`. I've changed the path to `api/...` and tested it for my Docker container. 
Note: this assumes that index.html is always served at the root path.