### PR TITLE
Fix download folder not found during docker install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,6 @@ __pycache__/
 /build/
 /.venv/
 /dist/
-/download/
 /gruut/
 *.pth
 *.onnx

--- a/download/.gitignore
+++ b/download/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
This fixes https://github.com/rhasspy/larynx/pull/62 by keeping the downloads empty folder but ignoring any further contents in it.