### PR TITLE
Jinga2 requirement fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,6 @@ __pycache__/
 /build/
 /.venv/
 /dist/
-/download/
 /gruut/
 *.pth
 *.onnx

--- a/download/.gitignore
+++ b/download/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ quart-cors~=0.5.0
 swagger-ui-py~=21.9.28
 torch~=1.8.0
 tqdm~=4.48.2
+Jinja2==3.0.3


### PR DESCRIPTION
Jinja2's escape module is required, this fixes the error "ImportError: cannot import name 'escape' from 'jinja2'"

Ref: https://stackoverflow.com/questions/71718167/importerror-cannot-import-name-escape-from-jinja2